### PR TITLE
fix(#406): fix text display in different langs

### DIFF
--- a/src/src.ejs
+++ b/src/src.ejs
@@ -95,8 +95,12 @@
         </div>
 
         <div class="input-field" id="length-pref-container">
-          <label for="length-pref" class="active"><%= length_pref %></label>
-          <input id="length-pref" type="number" onchange="lengthPref(this.value)" step="1" min="4" value="16" max="512">
+          <div>
+            <label for="length-pref" class="active"><%= length_pref %></label>
+          </div>
+          <div>
+            <input id="length-pref" type="number" onchange="lengthPref(this.value)" step="1" min="4" value="16" max="512">
+          </div>
         </div>
 
         <a class="btn waves-effect waves-light" onclick="reset()" id="reset">Reset preset usage</a>

--- a/src/style.scss
+++ b/src/style.scss
@@ -33,6 +33,8 @@ $link-color: $linkColor;
 // Variables;
 @import "materialize/sass/components/variables";
 
+$button-height: auto;
+
 $toast-action-color: $link-color;
 $toast-action-color: var(--linkColor);
 $toast-color: $internalColor;
@@ -603,7 +605,7 @@ label:focus {
 }
 
 .btn {
-  height: 2.4em;
+  min-height: 2.4em;
   line-height: 2.4em;
   font-family: 'Roboto', sans-serif;
   font-weight: 300;


### PR DESCRIPTION
Made the contents of 'length-pref-container' into two divs to stop them overlapping on language change, and also overriding materialize to allow for text to expand button size.

Fixes #406 